### PR TITLE
Add `manifest.yml` to `package.json` `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "files": [
     "index.js",
+    "manifest.yml",
     "package.json",
     "package-lock.json",
     "README.md"


### PR DESCRIPTION
The `manifest.yml` is not currently published to `npm`.