### PR TITLE
feat(sentry/netlify plugin): Add SENTRY_PIPELINE env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const fs = require('fs')
 const path = require('path')
 const SentryCli = require('@sentry/cli')
 const { promisify, inspect } = require('util')
+const packageJSON = require('./package.json');
 
 const writeFile = promisify(fs.writeFile)
 const deleteFile = promisify(fs.unlink)
@@ -121,6 +122,7 @@ async function createSentryConfig({ sentryOrg, sentryProject, sentryAuthToken })
   [defaults]
   project=${sentryProject}
   org=${sentryOrg}
+  pipeline=netlify/${packageJSON.version}
   `
   await writeFile(SENTRY_CONFIG_PATH, sentryConfigFile, { flag: 'w+' })
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const path = require('path')
 const SentryCli = require('@sentry/cli')
 const { promisify, inspect } = require('util')
-const packageJSON = require('./package.json');
+const { version } = require('./package.json');
 
 const writeFile = promisify(fs.writeFile)
 const deleteFile = promisify(fs.unlink)
@@ -122,7 +122,7 @@ async function createSentryConfig({ sentryOrg, sentryProject, sentryAuthToken })
   [defaults]
   project=${sentryProject}
   org=${sentryOrg}
-  pipeline=netlify/${packageJSON.version}
+  pipeline=netlify-build-plugin/${version}
   `
   await writeFile(SENTRY_CONFIG_PATH, sentryConfigFile, { flag: 'w+' })
 }


### PR DESCRIPTION
In order for us to determine where a release is being created, add the `SENTRY_PIPELINE` environment variable of `netlify/version`. Example you'd see in the debug output:

![Screen Shot 2020-07-17 at 10 32 58 AM](https://user-images.githubusercontent.com/29959063/87814646-f695bc80-c818-11ea-8ec1-91835ee79d7e.png)
