### PR TITLE
Add SENTRY_REPOSITORY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,28 @@ To link errors with releases, you must include a release ID (a.k.a version) wher
 #### Environment Variables
 
 You can use [site environment variables](https://docs.netlify.com/configure-builds/environment-variables/) to configure these values:
-| name | description | default |
-|------|-------------|---------|
-| `SENTRY_AUTH_TOKEN` | Authentication token for Sentry. | - |
-| `SENTRY_ORG` | The slug of the organization name in Sentry. | - |
-| `SENTRY_PROJECT` | The slug of the project name in Sentry. | - |
-| `SENTRY_RELEASE` | The release ID (a.k.a version). | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
-| `SENTRY_REPOSITORY` | Override the name of the target Sentry repository. | - |
-| `SENTRY_ENVIRONMENT` | The name of the environment being deployed to. | Netlify [deploy context](https://docs.netlify.com/site-deploys/overview/#deploy-contexts) |
-| `SENTRY_RELEASE_PREFIX` | Set this to prefix the release name with the value. | - |
+| name                    | description                                         | default                                                                                     |
+| ----------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `SENTRY_AUTH_TOKEN`     | Authentication token for Sentry.                    | -                                                                                           |
+| `SENTRY_ORG`            | The slug of the organization name in Sentry.        | -                                                                                           |
+| `SENTRY_PROJECT`        | The slug of the project name in Sentry.             | -                                                                                           |
+| `SENTRY_RELEASE`        | The release ID (a.k.a version).                     | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
+| `SENTRY_REPOSITORY`     | The name of the target Sentry repository.           | -                                                                                           |
+| `SENTRY_ENVIRONMENT`    | The name of the environment being deployed to.      | Netlify [deploy context](https://docs.netlify.com/site-deploys/overview/#deploy-contexts)   |
+| `SENTRY_RELEASE_PREFIX` | Set this to prefix the release name with the value. | -                                                                                           |
 
 
 #### Plugin Inputs
-| name | description | default |
-|------|-------------|---------|
-| `sentryOrg` | The slug of the organization name in Sentry. | - |
-| `sentryProject` | The slug of the project name in Sentry. | - |
-| `sentryAuthToken` | Authentication token for Sentry. We recommend this be set as an environment variable (see below). | - |
-| `sentryRelease` | The release ID (a.k.a version). | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
-| `sentryRepository` | Override the name of the target Sentry repository. | - |
-| `sourceMapPath` | Folder in which to scan for source maps to upload. | Netlify publish directory |
-| `sourceMapUrlPrefix` | Prefix for the location of source maps. | `"~/"` |
-| `skipSetCommits` | Set this to true if you want to disable commit tracking. | `false` |
-| `skipSourceMaps` | Set this to true if you want to disable sending source maps to Sentry. | `false` |
-| `releasePrefix` | Set this to prefix the release name with the value. | - |
-| `deployPreviews` | Set this to false if you want to skip running the build plugin on deploy previews. | `true` |
+| name                 | description                                                                                       | default                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `sentryOrg`          | The slug of the organization name in Sentry.                                                      | -                                                                                                            |
+| `sentryProject`      | The slug of the project name in Sentry.                                                           | -                                                                                                            |
+| `sentryAuthToken`    | Authentication token for Sentry. We recommend this be set as an environment variable (see below). | -                                                                                                            |
+| `sentryRelease`      | The release ID (a.k.a version).                                                                   | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata)                  |
+| `sentryRepository`   | The name of the target Sentry repository.                                                         | Derived from [REPOSITORY_URL](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
+| `sourceMapPath`      | Folder in which to scan for source maps to upload.                                                | Netlify publish directory                                                                                    |
+| `sourceMapUrlPrefix` | Prefix for the location of source maps.                                                           | `"~/"`                                                                                                       |
+| `skipSetCommits`     | Set this to true if you want to disable commit tracking.                                          | `false`                                                                                                      |
+| `skipSourceMaps`     | Set this to true if you want to disable sending source maps to Sentry.                            | `false`                                                                                                      |
+| `releasePrefix`      | Set this to prefix the release name with the value.                                               | -                                                                                                            |
+| `deployPreviews`     | Set this to false if you want to skip running the build plugin on deploy previews.                | `true`                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Save the internal integration token and any other environment variables as [site
 
 ![View of internal integration permissions.](images/netlify-environment-variables.png)
 
-The repository must  
-
 For more information about the parameters below, please see the [Sentry release management docs](https://docs.sentry.io/cli/releases/).
 
 ### Ensure Your SDK is Configured

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The Sentry Netlify build plugin:
 
 Before proceeding, you'll first want to ensure that your Sentry project is set up properly to track commit metadata. The easiest way to do that is to [install a repository integration](https://docs.sentry.io/product/releases/#install-repo-integration).
 
+By default, the linked Sentry repository will be parsed from the Netlify's `REPOSITORY_URL` environment variable. This behaviour can be overridden using the `SENTRY_REPOSITORY` environment variable.
+
 Make sure build plugins are enabled on your site to see the plugin run.
 
 ## Installation
@@ -50,6 +52,8 @@ Save the internal integration token and any other environment variables as [site
 
 ![View of internal integration permissions.](images/netlify-environment-variables.png)
 
+The repository must  
+
 For more information about the parameters below, please see the [Sentry release management docs](https://docs.sentry.io/cli/releases/).
 
 ### Ensure Your SDK is Configured
@@ -64,6 +68,7 @@ You can use [site environment variables](https://docs.netlify.com/configure-buil
 | `SENTRY_ORG` | The slug of the organization name in Sentry. | - |
 | `SENTRY_PROJECT` | The slug of the project name in Sentry. | - |
 | `SENTRY_RELEASE` | The release ID (a.k.a version). | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
+| `SENTRY_REPOSITORY` | Override the name of the target Sentry repository. | - |
 | `SENTRY_ENVIRONMENT` | The name of the environment being deployed to. | Netlify [deploy context](https://docs.netlify.com/site-deploys/overview/#deploy-contexts) |
 | `SENTRY_RELEASE_PREFIX` | Set this to prefix the release name with the value. | - |
 
@@ -75,6 +80,7 @@ You can use [site environment variables](https://docs.netlify.com/configure-buil
 | `sentryProject` | The slug of the project name in Sentry. | - |
 | `sentryAuthToken` | Authentication token for Sentry. We recommend this be set as an environment variable (see below). | - |
 | `sentryRelease` | The release ID (a.k.a version). | [COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata) |
+| `sentryRepository` | Override the name of the target Sentry repository. | - |
 | `sourceMapPath` | Folder in which to scan for source maps to upload. | Netlify publish directory |
 | `sourceMapUrlPrefix` | Prefix for the location of source maps. | `"~/"` |
 | `skipSetCommits` | Set this to true if you want to disable commit tracking. | `false` |

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
     const sentryRelease = process.env.SENTRY_RELEASE || inputs.sentryRelease || process.env.COMMIT_REF
     const releasePrefix = process.env.SENTRY_RELEASE_PREFIX || inputs.releasePrefix || ''
     const sentryEnvironment = process.env.SENTRY_ENVIRONMENT || process.env.CONTEXT
+    const sentryRepository = process.env.SENTRY_REPOSITORY || inputs.sentryRepository
     const sourceMapPath = inputs.sourceMapPath || PUBLISH_DIR
     const sourceMapUrlPrefix = inputs.sourceMapUrlPrefix || DEFAULT_SOURCE_MAP_URL_PREFIX
 
@@ -108,7 +109,7 @@ async function createSentryRelease({ pluginApi, release, sentryEnvironment, sour
 
   // https://docs.sentry.io/cli/releases/#sentry-cli-commit-integration
   if (!inputs.skipSetCommits) {
-    const repository = process.env.REPOSITORY_URL.split(/[:/]/).slice(-2).join('/')
+    const repository = sentryRepository || process.env.REPOSITORY_URL.split(/[:/]/).slice(-2).join('/')
     try {
       await cli.releases.setCommits(release, {
         repo: repository,

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ module.exports = {
         pluginApi,
         release,
         sentryEnvironment,
+        sentryRepository,
         sourceMapPath,
         sourceMapUrlPrefix
       })
@@ -75,7 +76,7 @@ module.exports = {
   }
 }
 
-async function createSentryRelease({ pluginApi, release, sentryEnvironment, sourceMapPath, sourceMapUrlPrefix }) {
+async function createSentryRelease({ pluginApi, release, sentryEnvironment, sentryRepository, sourceMapPath, sourceMapUrlPrefix }) {
   // default config file is read from ~/.sentryclirc
   const { constants, inputs, utils } = pluginApi
   const cli = new SentryCli()

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,8 @@ inputs:
     description: Authentication token for Sentry
   - name: sentryRelease
     description: The release ID (a.k.a version)
+  - name: sentryRepository
+    description: Override the name of the target Sentry repository
   - name: sourceMapPath
     description: Folder in which to scan for source maps to upload
   - name: sourceMapUrlPrefix

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ inputs:
   - name: sentryRelease
     description: The release ID (a.k.a version)
   - name: sentryRepository
-    description: Override the name of the target Sentry repository
+    description: The name of the target Sentry repository
   - name: sourceMapPath
     description: Folder in which to scan for source maps to upload
   - name: sourceMapUrlPrefix


### PR DESCRIPTION
Allow users to override the repository name passed to the cli.
This is useful for gitlab users where the repository name is not necessarily the same
as the URL (#21)