### PR TITLE
chore(deps): Remove rimraf from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "netlify-cli": "^2.48.0",
-    "prettier": "^2.8.4",
-    "rimraf": "^3.0.2"
+    "prettier": "^2.8.4"
   }
 }


### PR DESCRIPTION
This removes rimraf from our dev dependencies, as we don't use it anywhere.

Ref: WOR-2817