### PR TITLE
feat(sourcemaps): Add `deleteSourceMaps` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For more information about the parameters below, please see the [Sentry release 
 | `skipSetCommits` | - | If true, disable commit tracking. | `false` |
 | `skipSourceMaps` | - | If true, disable uploading source maps to Sentry. | `false` |
 | `deployPreviews` | - | If false, skip running the build plugin on preview deploys. | `true` |
+| `deleteSourceMaps` | SENTRY_DELETE_SOURCEMAPS | If true, delete source maps after uploading them to Sentry. May cause browser console errors if not used alongside your build tool's equivalent of webpack's [`hidden-source-map` option](https://webpack.js.org/configuration/devtool/). | `false` |
 
 ## `@sentry/netlify-build-plugin` vs. `@netlify/sentry`
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const path = require('path');
 const SentryCli = require('@sentry/cli');
 const { promisify, inspect } = require('util');
 const { version } = require('./package.json');
+const rimraf = require('rimraf');
 
 const writeFile = promisify(fs.writeFile);
 const deleteFile = promisify(fs.unlink);
@@ -37,6 +38,7 @@ module.exports = {
     const sentryRepository = process.env.SENTRY_REPOSITORY || inputs.sentryRepository;
     const sourceMapPath = inputs.sourceMapPath || PUBLISH_DIR;
     const sourceMapUrlPrefix = inputs.sourceMapUrlPrefix || DEFAULT_SOURCE_MAP_URL_PREFIX;
+    const shouldDeleteMaps = inputs.deleteSourceMaps || SENTRY_DELETE_SOURCEMAPS;
 
     if (RUNNING_IN_NETLIFY) {
       if (IS_PREVIEW && !inputs.deployPreviews) {
@@ -83,6 +85,13 @@ module.exports = {
       console.log();
 
       await deleteSentryConfig();
+
+      if (shouldDeleteMaps) {
+        console.log('Removing source map files.');
+        await rimraf(sourceMapPath, {
+          filter: filepath => filepath.endsWith('.map'),
+        });
+      }
     }
   },
 };

--- a/manifest.yml
+++ b/manifest.yml
@@ -25,3 +25,6 @@ inputs:
   - name: deployPreviews
     description: Set this to false if you want to skip running the build plugin on deploy previews.
     default: True
+  - name: deleteSourceMaps
+    description: If true, delete source maps after uploading them to Sentry.
+    default: False

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@sentry/cli": "^1.52.3"
+    "@sentry/cli": "^1.52.3",
+    "rimraf": "^4.3.1"
   },
   "engines": {
     "node": ">=8.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4617,6 +4617,16 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^9.2.0:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.2.1.tgz#f47e34e1119e7d4f93a546e75851ba1f1e68de50"
+  integrity sha512-Pxxgq3W0HyA3XUvSXcFhRSs+43Jsx0ddxcFrbjxNGkL2Ak5BAUBxLqI5G6ADDeCHLfzzXFhe0b1yYcctGmytMA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^7.4.1"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
+
 global-cache-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/global-cache-dir/-/global-cache-dir-1.0.1.tgz#2c0820b43bae8a6ef8adf96fd23ec6bbf52dd13c"
@@ -5866,6 +5876,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
 macos-release@^2.2.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.1.tgz#bccac4a8f7b93163a8d163b8ebf385b3c5f55bf9"
@@ -6074,6 +6089,13 @@ minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^7.4.1:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.2.tgz#157e847d79ca671054253b840656720cb733f10f"
+  integrity sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -6094,7 +6116,7 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-minipass@^4.0.0:
+minipass@^4.0.0, minipass@^4.0.2, minipass@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.4.tgz#7d0d97434b6a19f59c5c3221698b48bbf3b2cd06"
   integrity sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==
@@ -6994,6 +7016,14 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.6.1.tgz#dab45f7bb1d3f45a0e271ab258999f4ab7e23132"
+  integrity sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==
+  dependencies:
+    lru-cache "^7.14.1"
+    minipass "^4.0.2"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -7614,6 +7644,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.3.1.tgz#ccb3525e39100478acb334fae6d23029b87912ea"
+  integrity sha512-GfHJHBzFQra23IxDzIdBqhOWfbtdgS1/dCHrDy+yvhpoJY5TdwdT28oWaHWfRpKFDLd3GZnGTx6Mlt4+anbsxQ==
+  dependencies:
+    glob "^9.2.0"
 
 rollup-plugin-inject@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
_h/t to @carchrae for the initial work on this_

This adds a new option, `deleteSourceMaps` (or `SENTRY_DELETE_SOURCEMAPS` as an env variable), which will delete sourcemaps after uploading them.

Really this should be done at the `sentry-cli` level (see https://github.com/getsentry/sentry-cli/issues/1318), but in the meantime, we can do it manually.

Fixes https://github.com/getsentry/sentry-netlify-build-plugin/issues/40

Ref: WOR-2638