### PR TITLE
(bug) Fix SENTRY_DELETE_SOURCEMAPS not being defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
     const sentryRepository = process.env.SENTRY_REPOSITORY || inputs.sentryRepository;
     const sourceMapPath = inputs.sourceMapPath || PUBLISH_DIR;
     const sourceMapUrlPrefix = inputs.sourceMapUrlPrefix || DEFAULT_SOURCE_MAP_URL_PREFIX;
-    const shouldDeleteMaps = inputs.deleteSourceMaps || SENTRY_DELETE_SOURCEMAPS;
+    const shouldDeleteMaps = process.env.SENTRY_DELETE_SOURCEMAPS || inputs.deleteSourceMaps;
 
     if (RUNNING_IN_NETLIFY) {
       if (IS_PREVIEW && !inputs.deployPreviews) {


### PR DESCRIPTION
This fixes a bug with the recently merged [feat(sourcemaps): Add deleteSourceMaps option](https://github.com/getsentry/sentry-netlify-build-plugin/pull/76). The `SENTRY_DELETE_SOURCEMAPS` wasn't actually defined. This grabs the value from the env vars per the docs.