### PR TITLE
(feat) enable local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ For more information about the parameters below, please see the [Sentry release 
 | `skipSourceMaps` | - | If true, disable uploading source maps to Sentry. | `false` |
 | `deployPreviews` | - | If false, skip running the build plugin on preview deploys. | `true` |
 | `deleteSourceMaps` | SENTRY_DELETE_SOURCEMAPS | If true, delete source maps after uploading them to Sentry. May cause browser console errors if not used alongside your build tool's equivalent of webpack's [`hidden-source-map` option](https://webpack.js.org/configuration/devtool/). | `false` |
+| `enableLocal` | SENTRY_LOCAL | If true, create a Sentry release for local builds. | `false` |
 
 ## `@sentry/netlify-build-plugin` vs. `@netlify/sentry`
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ module.exports = {
     const sourceMapPath = inputs.sourceMapPath || PUBLISH_DIR;
     const sourceMapUrlPrefix = inputs.sourceMapUrlPrefix || DEFAULT_SOURCE_MAP_URL_PREFIX;
     const shouldDeleteMaps = inputs.deleteSourceMaps || SENTRY_DELETE_SOURCEMAPS;
+    const enableLocal = process.env.SENTRY_LOCAL || inputs.enableLocal;
 
-    if (RUNNING_IN_NETLIFY) {
+    if (RUNNING_IN_NETLIFY || enableLocal) {
       if (IS_PREVIEW && !inputs.deployPreviews) {
         console.log('Skipping Sentry release creation - Deploy Preview');
         return;

--- a/manifest.yml
+++ b/manifest.yml
@@ -28,3 +28,6 @@ inputs:
   - name: deleteSourceMaps
     description: If true, delete source maps after uploading them to Sentry.
     default: False
+  - name: enableLocal
+    description: Create a Sentry release for local builds.
+    default: False


### PR DESCRIPTION
This feature enables creating a release in other build environments outside of Netlify. I've used the `local` term to be consistent with internal naming, and Netlify patterns.

When using the netlify CLI to run a build on other CI systems (Github Actions for example), enabling this flag will override the default behavior of preventing "local" builds (i.e. builds outside of Netlify) from creating a release.